### PR TITLE
Issue 2 - Readme refers to MIT license incorrectly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,4 +206,4 @@ Use the [issue tracker](https://github.com/pingidentity/pf-authn-js-widget/issue
 
 # License
 
-This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more information.
+This project is licensed under the Apache license. See the [LICENSE](LICENSE) file for more information.


### PR DESCRIPTION
Problem: the readme refers to MIT license instead of Apache 2.0 License.
Solution: updated the readme to refer to Apache license.
Closes Issue 2.