### PR TITLE
Closes #19 - The general error renderer was always being called due t…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export default class AuthnWidget {
       }
       this.store
         .dispatch('GET_FLOW')
-        .catch(this.generalErrorRenderer(AuthnWidget.COMMUNICATION_ERROR_MSG));
+        .catch(() => this.generalErrorRenderer(AuthnWidget.COMMUNICATION_ERROR_MSG));
     } catch (err) {
       console.error(err);
       this.generalErrorRenderer(err.message);


### PR DESCRIPTION
…o invalid javascript syntax. Changed the catch block to call a function to display the error message when the catch block is actually hit.