### PR TITLE
Fix error message upon mismatched current and new password.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -344,7 +344,9 @@ export default class AuthnWidget {
     let pass1 = document.querySelector('#newpassword');
     let pass2 = document.querySelector('#verifypassword');
     if (pass1.value !== pass2.value) {
-      this.store.dispatchErrors('New passwords do not match.');
+      let errors = [];
+      errors.push('New passwords do not match.');
+      this.store.dispatchErrors(errors);
       return false;
     } else {
       this.store.clearErrors();


### PR DESCRIPTION
During password change and reset, the new password and the verify new password fields were compared but the error message wasn't reported to the user. This fix seems to do the trick.