### PR TITLE
Changed variables that are stashed in the store to only be accessed t…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,16 +60,15 @@ export default class AuthnWidget {
    * @param {object} options object containing additional options such as flowId and divId
    */
   constructor(baseUrl, options) {
-    this.flowId = (options && options.flowId) || this.getBrowserFlowId();
+    let flowId = (options && options.flowId) || this.getBrowserFlowId();
     this.divId = (options && options.divId) || 'authnwidget';
     if (!baseUrl) {
       throw new Error(AuthnWidget.BASE_URL_REQUIRED_MSG);
     }
     this.captchaDivId = 'invisibleRecaptchaId';
     this.assets = new Assets(options);
-    this.baseUrl = baseUrl;
     this.invokeReCaptcha = options && options.invokeReCaptcha;
-    this.checkRecaptcha = options && options.checkRecaptcha;
+    let checkRecaptcha = options && options.checkRecaptcha;
     this.grecaptcha = options && options.grecaptcha;
     this.deviceProfileScript = options && options.deviceProfileScript;
     this.dispatch = this.dispatch.bind(this);
@@ -105,7 +104,7 @@ export default class AuthnWidget {
     this.eventHandler = new Map();  //state -> eventHandlers
     this.postRenderCallbacks = new Map();
     this.actionModels = new Map();
-    this.store = new Store(this.flowId, this.baseUrl, this.checkRecaptcha, options);
+    this.store = new Store(flowId, baseUrl, checkRecaptcha, options);
     this.store.registerListener(this.render);
     AuthnWidget.CORE_STATES.forEach(state => this.registerState(state));
 
@@ -154,7 +153,7 @@ export default class AuthnWidget {
 
   init() {
     try {
-      if (!this.flowId) {
+      if (!this.store.flowId) {
         throw new Error(AuthnWidget.FLOW_ID_REQUIRED_MSG);
       }
       this.renderSpinnerTemplate();
@@ -551,7 +550,7 @@ export default class AuthnWidget {
 
   async pollCheckGet(currentVerificationCode, timeout) {
     let fetchUtil = this.store.fetchUtil;
-    let result = await fetchUtil.postFlow(this.flowId, 'poll', '{}');
+    let result = await fetchUtil.postFlow(this.store.flowId, 'poll', '{}');
     let newState = await result.json();
 
     let pollAgain =

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ describe('AuthnWidget index', () => {
 
   test('Test valid constructor without options', () => {
     const authn = new AuthnWidget('https://localhost:9031');
-    expect(authn.baseUrl).toBe('https://localhost:9031');
+    expect(authn.store.baseUrl).toBe('https://localhost:9031');
     expect(authn.actionModels.has('checkUsernamePassword')).toBeTruthy();
     expect(AuthnWidget.CORE_STATES).toContain('USERNAME_PASSWORD_REQUIRED');
     expect(authn.store !== null).toBeTruthy();


### PR DESCRIPTION
…hrough the store.

In redirectless mode, the flowId might never get set in the constructor, but will get set in the store once the flowId is retrieved.

This fixes an issue with the verify flow when we try to poll the adapter to check verification status and the widget re-renders each time. Essentially we were posting an action without a flow ID and getting an invalid request response back, which would cause a GET_FLOW to happen.