### PR TITLE
do not display password fields on registration required if authenticated by alternative authN source

### DIFF
--- a/src/partials/registration_required.hbs
+++ b/src/partials/registration_required.hbs
@@ -22,6 +22,7 @@
       {{/each}}
     </div>
 
+    {{#unless authenticationSource}}
     <div class="stack stack--small">
       <div class="float-label"><input type="password"
                                       class="text-input float-label__input required"
@@ -39,6 +40,7 @@
         <label class="float-label__label" for="newpassword">Verify New Password</label>
       </div>
     </div>
+    {{/unless}}
     {{#if showThisIsMyDevice}}
       <div>
         <label class="checkbox">


### PR DESCRIPTION
password fields are not required if the user has already been authenticated by alternative authentication source.