### PR TITLE
Fixed device pairing for non-webauthn use cases.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -489,8 +489,7 @@ export default class AuthnWidget {
       let devicePairingMethod = source.dataset['mfaDevicePairingSelection'].split('.');
       let data = {
         'devicePairingMethod': {
-          'deviceType': devicePairingMethod[0],
-          'userAgent': userAgent
+          'deviceType': devicePairingMethod[0]
         }
       };
       if (devicePairingMethod.length > 1 && devicePairingMethod[1] !== '') {
@@ -498,6 +497,7 @@ export default class AuthnWidget {
       }
       if (devicePairingMethod[0] === 'SECURITY_KEY' || devicePairingMethod[0] === 'PLATFORM' || devicePairingMethod[0] === 'FIDO2' ) {
         data['devicePairingMethod']['relyingPartyId'] = rpId;
+        data['devicePairingMethod']['userAgent'] = userAgent;
       }
       this.store.dispatch('POST_FLOW', "selectDevicePairingMethod", JSON.stringify(data));
     } else {


### PR DESCRIPTION
This fix is needed for adapter version 2.2 and greater.

The widget will send userAgent for all pairing types, but it is now only valid for webauthn methods. Pairing other types will result in the error "Unrecognized field name was found : devicePairingMethod/userAgent"