### PR TITLE
Adding Enterprise Captcha support.

### DIFF
--- a/src/utils/risk-providers/recaptcha-enterprise.js
+++ b/src/utils/risk-providers/recaptcha-enterprise.js
@@ -1,0 +1,70 @@
+const LOG_PREFIX = '[reCAPTCHA Enterprise] ';
+
+export default class RecaptchaEnterprise {
+  constructor(attributes, store) {
+    this.attributes = attributes;
+    this.store = store;
+    window.recaptchaEnterprise_loaded = window.recaptchaEnterprise_loaded || false;
+    if (window.recaptchaEnterprise_loaded) {
+      console.log(LOG_PREFIX + 'already initialized, skipping initialization');
+      return;
+    }
+    window.recaptchaEnterprise_onload = () => {
+      console.log(LOG_PREFIX + 'script onload event triggered');
+      window.recaptchaEnterprise_loaded = true;
+      renderCaptcha(this.attributes.siteKey);
+    }
+  }
+
+  isLoaded() {
+    return window.recaptchaEnterprise_loaded;
+  }
+
+  getScriptHeader() {
+    const script = document.createElement('script');
+    script.src = 'https://www.google.com/recaptcha/enterprise.js?onload=recaptchaEnterprise_onload&render=explicit';
+    script.setAttribute("async", "");
+    script.setAttribute("defer", "");
+    return script;
+  }
+
+  getUIElement() {
+    return '<div id="invisibleRecaptchaId"></div>';
+  }
+
+  render() {
+    // just render the captcha if script tag is loaded
+    if (this.isLoaded()) {
+      console.log(LOG_PREFIX + 'script is loaded.');
+      renderCaptcha(this.attributes.siteKey);
+      return;
+    }
+
+    // load the captcha script,
+    // render will get triggered after the script is loaded
+    console.log(LOG_PREFIX + 'loading script');
+    document.head.appendChild(this.getScriptHeader());
+    return;
+  }
+
+  execute(actionId, formData) {
+    grecaptcha.enterprise.ready(() => {
+      grecaptcha.enterprise.execute(window.recaptchaEnterprise_render_result, { action: this.attributes.action })
+        .then((token) => {
+          console.log(LOG_PREFIX + `captcha response: ${token}`);
+          // add g-recaptcha-response to form data
+          formData['captchaResponse'] = token;
+          console.log(LOG_PREFIX + `${formData}`);
+          this.store.dispatch('POST_FLOW', actionId, JSON.stringify(formData));
+        });
+    });
+  }
+}
+
+const renderCaptcha = (siteKey) => {
+  console.log(LOG_PREFIX + 'rendering');
+  window.recaptchaEnterprise_render_result = grecaptcha.enterprise.render('invisibleRecaptchaId', {
+    'sitekey': `${siteKey}`,
+    'size': 'invisible'
+  });
+}

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -1,7 +1,7 @@
 import handlebars from 'handlebars'
 import RecaptchaV2Invisible from "./risk-providers/recaptcha-v2-invisible";
 import RecaptchaV3 from "./risk-providers/recaptcha-v3";
-import RecaptchaEnterprise from "./risk-providers/recaptcha-v3";
+import RecaptchaEnterprise from "./risk-providers/recaptcha-enterprise";
 import Signals from "./risk-providers/signals";
 
 const CAPTCHA_TYPE_RECAPTCHA_V2_INVISIBLE = "reCAPTCHA v2 Invisible";

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -1,10 +1,12 @@
 import handlebars from 'handlebars'
 import RecaptchaV2Invisible from "./risk-providers/recaptcha-v2-invisible";
 import RecaptchaV3 from "./risk-providers/recaptcha-v3";
+import RecaptchaEnterprise from "./risk-providers/recaptcha-v3";
 import Signals from "./risk-providers/signals";
 
 const CAPTCHA_TYPE_RECAPTCHA_V2_INVISIBLE = "reCAPTCHA v2 Invisible";
 const CAPTCHA_TYPE_RECAPTHCA_V3 = "reCAPTCHA v3";
+const CAPTCHA_TYPE_RECAPTCHA_ENTERPRISE = "reCAPTCHA Enterprise";
 const CAPTCHA_TYPE_PING_ONE_PROTECT_OLD_NAME = "PingOne Protect Provider";
 const CAPTCHA_TYPE_PING_ONE_PROTECT = "PingOne Protect";
 
@@ -37,6 +39,8 @@ export default class RiskUtils {
         return new RecaptchaV2Invisible(this.attributes, this.store);
       case CAPTCHA_TYPE_RECAPTHCA_V3:
         return new RecaptchaV3(this.attributes, this.store);
+      case CAPTCHA_TYPE_RECAPTCHA_ENTERPRISE:
+        return new RecaptchaEnterprise(this.attributes, this.store);
       case CAPTCHA_TYPE_PING_ONE_PROTECT_OLD_NAME:
       case CAPTCHA_TYPE_PING_ONE_PROTECT:
         return new Signals(this.attributes, this.store);

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -5,7 +5,7 @@ import RecaptchaEnterprise from "./risk-providers/recaptcha-enterprise";
 import Signals from "./risk-providers/signals";
 
 const CAPTCHA_TYPE_RECAPTCHA_V2_INVISIBLE = "reCAPTCHA v2 Invisible";
-const CAPTCHA_TYPE_RECAPTHCA_V3 = "reCAPTCHA v3";
+const CAPTCHA_TYPE_RECAPTCHA_V3 = "reCAPTCHA v3";
 const CAPTCHA_TYPE_RECAPTCHA_ENTERPRISE = "reCAPTCHA Enterprise";
 const CAPTCHA_TYPE_PING_ONE_PROTECT_OLD_NAME = "PingOne Protect Provider";
 const CAPTCHA_TYPE_PING_ONE_PROTECT = "PingOne Protect";
@@ -37,7 +37,7 @@ export default class RiskUtils {
     switch (this.type) {
       case CAPTCHA_TYPE_RECAPTCHA_V2_INVISIBLE:
         return new RecaptchaV2Invisible(this.attributes, this.store);
-      case CAPTCHA_TYPE_RECAPTHCA_V3:
+      case CAPTCHA_TYPE_RECAPTCHA_V3:
         return new RecaptchaV3(this.attributes, this.store);
       case CAPTCHA_TYPE_RECAPTCHA_ENTERPRISE:
         return new RecaptchaEnterprise(this.attributes, this.store);


### PR DESCRIPTION
**What**

- This story is to add Google Enterprise reCAPTCHA plugin support to the authn js widget.
- The backend will require PingFederate 12.2 which is due to be released in Q4 of 2024.

**How**

- Added front-end javascript for new risk-provider:

- recaptcha-enterprise.js

- Modified riskUtils.js to support new risk-provider

**Testing Performed**

Tested
- JavaScript Widget for the PingFederate Authentication API

**Relevant logs and/or screenshots**
 
![image](https://github.com/user-attachments/assets/fbd7729c-900c-4d0a-9aec-dc565abfcb03)
