### PR TITLE
Show an error when a redirect is required in redirectless mode.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,10 @@ export default class AuthnWidget {
     return "Unable to start the authentication flow, please contact your system administrator.";
   }
 
+  static get REDIRECTLESS_REDIRECT_REQUIRED_ERROR_MSG() {
+    return "The widget is in redirectless mode and redirect is required to complete authentication.";
+  }
+
   static get FLOW_ID_REQUIRED_MSG() {
     return "'flowId' query parameter is required.";
   }
@@ -260,6 +264,7 @@ export default class AuthnWidget {
     this.eventHandler = new Map();  //state -> eventHandlers
     this.postRenderCallbacks = new Map();
     this.actionModels = new Map();
+    this.redirectlessEnabled = false;
     this.store = new Store(flowId, baseUrl, options);
     this.store.registerListener(this.render);
     AuthnWidget.CORE_STATES.forEach(state => this.registerState(state), this);
@@ -423,6 +428,7 @@ export default class AuthnWidget {
     try {
       console.log(configuration);
       redirectlessConfigValidator(configuration);
+      this.redirectlessEnabled = true;
       this.addPostRenderCallback('COMPLETED', (state) => completeStateCallback(state, configuration));
       this.addPostRenderCallback('FAILED', (state) => failedStateCallback(state, configuration));
       const isCookieless = Boolean(configuration.cookieless);
@@ -541,6 +547,10 @@ export default class AuthnWidget {
 
   openExternalAuthnPopup() {
     if (this.store.getStore().presentationMode === 'REDIRECT') {
+      if (this.redirectlessEnabled) {
+        this.generalErrorRenderer(AuthnWidget.REDIRECTLESS_REDIRECT_REQUIRED_ERROR_MSG);
+        return;
+      }
       window.location.replace(this.store.getStore().authenticationUrl);
     } else {
       if (document.querySelector("#externalAuthnHeaderId")) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -56,5 +56,28 @@ describe('AuthnWidget index', () => {
     expect(authn.eventHandler.get('USERNAME_PASSWORD_REQUIRED')).toContain(customHandler);
   });
 
-});
+  test('shows an error instead of redirecting in redirectless mode', () => {
+    const authn = new AuthnWidget('https://localhost:9031');
+    const generalErrorRendererSpy = jest.spyOn(authn, 'generalErrorRenderer').mockImplementation(() => {});
 
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { ...originalLocation, replace: jest.fn() };
+
+    authn.redirectlessEnabled = true;
+    authn.store.state = {
+      presentationMode: 'REDIRECT',
+      authenticationUrl: 'https://localhost:9031/example'
+    };
+
+    authn.openExternalAuthnPopup();
+
+    expect(generalErrorRendererSpy).toHaveBeenCalledWith(
+      'The widget is in redirectless mode and redirect is required to complete authentication.'
+    );
+    expect(window.location.replace).not.toHaveBeenCalled();
+
+    window.location = originalLocation;
+  });
+
+});


### PR DESCRIPTION
## What

Social adapter can return the state EXTERNAL_AUTHENTICATION_REQUIRED with a redirect presentation mode.

```
{
  "id": "12345",
  "pluginTypeId": "mySocialPluginID",
  "status": "EXTERNAL_AUTHENTICATION_REQUIRED",
  "authenticationUrl": "https://mysociallogin.com/login",
  "presentationMode": "REDIRECT",
  "_links": {
    "cancelAuthentication": {
      "href": "https://example.com9031/pf-ws/authn/flows/9nxAJ"
    },
    "self": {
      "href": "https://example.com:9031/pf-ws/authn/flows/9nxAJ"
    }
  }
}
```

If the widget is being used in redirectless mode, it will still redirect the browser to this endpoint. The transaction will fail when the user is redirected back to PingFederate after successfully authenticating at the social provider. This is because there is no "resumeURL" or way to redirect the user back to where the widget is hosted to continue the transaction.

## How

The widget will now check to see if its in redirectless mode before redirecting the browser to the authenticationUrl specified in the response. If it is in redirectless mode it will display an error indicating such.

## Testing Performed

Tried redirect and popup modes for both normal and redirectless modes with the widget.