### PR TITLE
NEO-5628: support auto-redirect on desktop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1419,8 +1419,10 @@ export default class AuthnWidget {
 
     if (data.sameDevice && data.webVerificationUrl !== undefined &&
         (this.store.getPreviousStore().verificationCode !== data.verificationCode)) {
+      // avoid splash qr screen before redirected to webverify
+      document.body.hidden = true;
       // open weblink in current tab on same device, with autoRedirectToPF & skipIntroScreen
-      data.webVerificationUrl += '&skipIntro=1';
+      data.webVerificationUrl += '&skipIntro=1&dt=1';
       console.log("web link opens in same device: " + data.webVerificationUrl);
       window.open(data.webVerificationUrl, '_self');
     }
@@ -1563,11 +1565,12 @@ export default class AuthnWidget {
   }
 
   deviceAuthentication() {
+    let dataStore = this.store.getStore();
     document.getElementById("AuthnWidgetForm").style.pointerEvents = "none";
 
     // javascript from http://detectmobilebrowser.com/
     const isMobile = (function(a){return /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4));})(navigator.userAgent||navigator.vendor||window.opera);
-    const device = isMobile ? "self" : "other";
+    const device = (isMobile || dataStore.desktopAutoRedirect) ? "self" : "other";
     const data = { "deviceAuthentication": device };
     this.store.dispatch('POST_FLOW', "deviceAuthentication", JSON.stringify(data));
   }


### PR DESCRIPTION
## What

Support auto-redirect on desktop to allow verification on same device.

## How

The auto-redirect on same-device feature is already implemented for mobile device. Now we're allowing desktop to do the same, by adding a new config `desktopAutoRedirect` to PF verify adapter. When this config is enabled, `deviceAuthentication` will always be set to `self`, indicating it's same-device flow, so that the flow will open webVerification link in the same tab, then auto-redirect back to PF when document collection is complete. 
The other minor change is to hide the 2-second QR screen during redirecting to webVerify.

## Testing Performed

Test flow on desktop:
- when `desktopAutoRedirect` is enabled, flow auto-redirects to webVerify then back to PF all in the same tab; 
- when it's disabled, QR/verificationMethod screen is displayed and does polling on current device, in the meantime, user starts webVerify on another mobile device.
Regression test flow on mobile:
- flow always does auto-redirect regardless of the config setting.

## Relevant logs and/or screenshots

```
      // avoid splash qr screen before redirected to webverify
      document.body.hidden = true;
      // open weblink in current tab on same device, with autoRedirectToPF & skipIntroScreen
      data.webVerificationUrl += '&skipIntro=1&dt=1';
```
```
    const device = (isMobile || dataStore.desktopAutoRedirect) ? "self" : "other";
    const data = { "deviceAuthentication": device };
```